### PR TITLE
Decoupled db initialization from create app factory

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,9 @@
 from flask_login import LoginManager
 from app_factory import create_app
+from utils.database import populate_database
 
 if __name__ == '__main__':
     login_manager = LoginManager()
-    app_config = {
-        'INSERT_DUMMY_DATA': True,
-        'SEED_DATABASE_FOR_TESTING': True,
-    }
-    app = create_app(login_manager=login_manager, test_config=app_config)
+    app = create_app(login_manager=login_manager)
+    populate_database(app.config['SQLALCHEMY_DATABASE_URI'])
     app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -1,9 +1,7 @@
 from flask_login import LoginManager
 from app_factory import create_app
-from utils.database import populate_database
 
 if __name__ == '__main__':
     login_manager = LoginManager()
     app = create_app(login_manager=login_manager)
-    populate_database(app.config['SQLALCHEMY_DATABASE_URI'])
     app.run(debug=True)

--- a/app_factory.py
+++ b/app_factory.py
@@ -10,7 +10,7 @@ from routes.jobs import job_bp
 from routes.teams import teams_bp
 from routes.properties import properties_bp
 from services.user_service import UserService
-from utils.database import populate_database
+from utils.populate_database import populate_database
 
 def create_app(login_manager=LoginManager(), config_override=dict()):
     """

--- a/app_factory.py
+++ b/app_factory.py
@@ -11,7 +11,7 @@ from routes.teams import teams_bp
 from routes.properties import properties_bp
 from services.user_service import UserService
 
-def create_app(login_manager=LoginManager(), test_config=None):
+def create_app(login_manager=LoginManager(), config_override=dict()):
     """
     Creates and configures the Flask application.
 
@@ -25,18 +25,13 @@ def create_app(login_manager=LoginManager(), test_config=None):
         Flask: The configured Flask application instance.
     """
     app = Flask(__name__, instance_relative_config=True)
-    if test_config:
+    if config_override.get('TESTING', False):
         app.config.from_object(TestConfig)
-        app.config.update(test_config) # Apply additional test config overrides
-
-        try: # Ensure the instance directory exists
-            os.makedirs(app.instance_path)
-        except OSError:
-            pass
     else: 
         app.config.from_object(Config)
     
-    Session = init_db(app.config['DATABASE'])
+    app.config.update(config_override)
+    Session = init_db(app.config['SQLALCHEMY_DATABASE_URI'])
     app.config['SQLALCHEMY_SESSION'] = Session
     
     login_manager.login_view = 'user.login'

--- a/app_factory.py
+++ b/app_factory.py
@@ -1,7 +1,7 @@
 # app_factory.py
 import os
 import secrets
-from flask import Flask, redirect, url_for, request, Response
+from flask import Flask, redirect, url_for, request, Response, abort
 from flask_login import LoginManager
 from config import Config, TestConfig
 from database import init_db, get_db, teardown_db
@@ -31,6 +31,8 @@ def create_app(login_manager=LoginManager(), config_override=dict()):
         populate_database(app.config['SQLALCHEMY_DATABASE_URI'])
     else: 
         app.config.from_object(Config)
+        if not app.config.get('SECRET_KEY'):
+            abort(500, "SECRET_KEY is not set. Please set the SECRET_KEY environment variable for production.")
     
     app.config.update(config_override)
     Session = init_db(app.config['SQLALCHEMY_DATABASE_URI'])

--- a/app_factory.py
+++ b/app_factory.py
@@ -10,6 +10,7 @@ from routes.jobs import job_bp
 from routes.teams import teams_bp
 from routes.properties import properties_bp
 from services.user_service import UserService
+from utils.database import populate_database
 
 def create_app(login_manager=LoginManager(), config_override=dict()):
     """
@@ -27,6 +28,7 @@ def create_app(login_manager=LoginManager(), config_override=dict()):
     app = Flask(__name__, instance_relative_config=True)
     if config_override.get('TESTING', False):
         app.config.from_object(TestConfig)
+        populate_database(app.config['SQLALCHEMY_DATABASE_URI'])
     else: 
         app.config.from_object(Config)
     

--- a/config.py
+++ b/config.py
@@ -24,4 +24,3 @@ class TestConfig(Config):
     TESTING = True
     SEED_DATABASE_FOR_TESTING = True
     INSERT_DUMMY_DATA = True
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'

--- a/config.py
+++ b/config.py
@@ -17,10 +17,6 @@ class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY') or secrets.token_bytes(32)
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or f'sqlite:///{os.path.join("instance", "cleanit.db")}'
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SEED_DATABASE_FOR_TESTING = False
-    INSERT_DUMMY_DATA = False
 
 class TestConfig(Config):
     TESTING = True
-    SEED_DATABASE_FOR_TESTING = True
-    INSERT_DUMMY_DATA = True

--- a/config.py
+++ b/config.py
@@ -1,3 +1,6 @@
+import secrets
+import os
+
 DATETIME_FORMATS = {
     "DATE_FORMAT": "%d-%m-%Y",
     "DATE_FORMAT_FLATPICKR": "d-m-Y",
@@ -9,3 +12,16 @@ DATETIME_FORMATS = {
     "TIME_FORMAT_FLATPICKR": "H:i"
 }
 BACK_TO_BACK_THRESHOLD = 15 # MINUTES
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY') or secrets.token_bytes(32)
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or f'sqlite:///{os.path.join("instance", "cleanit.db")}'
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SEED_DATABASE_FOR_TESTING = False
+    INSERT_DUMMY_DATA = False
+
+class TestConfig(Config):
+    TESTING = True
+    SEED_DATABASE_FOR_TESTING = True
+    INSERT_DUMMY_DATA = True
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'

--- a/controllers/users_controller.py
+++ b/controllers/users_controller.py
@@ -232,7 +232,10 @@ def login():
             login_user(user)
             flash(f'Welcome back, {user.first_name}!', 'success')
             next = request.args.get('next')
-            if not validate_request_host(next, request.host, current_app.debug):
+            dev_mode = current_app.config.get('DEBUG', False)
+            if not dev_mode:
+                dev_mode = current_app.config.get('TESTING', False)
+            if not validate_request_host(next, request.host, dev_mode):
                 _return = abort(400)
             _return = redirect(next or url_for('job.timetable')) # Redirect to job.timetable after successful login
         else:

--- a/controllers/users_controller.py
+++ b/controllers/users_controller.py
@@ -232,11 +232,16 @@ def login():
             login_user(user)
             flash(f'Welcome back, {user.first_name}!', 'success')
             next = request.args.get('next')
+
+            # Set the dev mode flag to true in order to skip host validation if in debug or testing mode
             dev_mode = current_app.config.get('DEBUG', False)
             if not dev_mode:
                 dev_mode = current_app.config.get('TESTING', False)
+            
+            # Validate the 'next' parameter to prevent open redirect vulnerabilities
             if not validate_request_host(next, request.host, dev_mode):
                 _return = abort(400)
+                
             _return = redirect(next or url_for('job.timetable')) # Redirect to job.timetable after successful login
         else:
             flash('Invalid email or password', 'error')

--- a/database.py
+++ b/database.py
@@ -379,9 +379,9 @@ def create_initial_properties_and_jobs(session, owner, cleaner, initial_team, al
     print("Initial jobs created and assigned for deterministic testing.")
     return property1, property_alpha
 
-def seed_database(Session):
+def insert_dummy_data(Session):
     """
-    Seeds the database with a consistent set of deterministic test data.
+    Populates the database with a consistent set of deterministic test data.
     This includes users, teams, properties, and jobs.
     This function clears existing data before seeding to ensure a clean state.
 
@@ -395,5 +395,3 @@ def seed_database(Session):
     create_initial_properties_and_jobs(session, owner, cleaner, initial_team, alpha_team, beta_team, charlie_team, delta_team)
     
     session.close()
-    print("Test database seeded with deterministic data.")
-

--- a/database.py
+++ b/database.py
@@ -165,21 +165,17 @@ class Assignment(Base):
                       )
 
 # Database initialization function
-def init_db(app, database_path: str, seed_data: bool = False):
+def init_db(database_path: str):
     """
-    Initializes the database, creates all tables, and optionally seeds it with test data.
+    Initializes the database and creates all tables.
 
     Args:
-        app: The Flask application instance.
         database_path (str): The path to the SQLite database file.
         seed_data (bool): If True, the database will be seeded with deterministic test data.
     """
-    engine = create_engine(f'sqlite:///{database_path}')
+    engine = create_engine(database_path)
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
-
-    if seed_data:
-        seed_test_data(Session)
 
     return Session
 

--- a/database.py
+++ b/database.py
@@ -379,7 +379,7 @@ def create_initial_properties_and_jobs(session, owner, cleaner, initial_team, al
     print("Initial jobs created and assigned for deterministic testing.")
     return property1, property_alpha
 
-def seed_test_data(Session):
+def seed_database(Session):
     """
     Seeds the database with a consistent set of deterministic test data.
     This includes users, teams, properties, and jobs.

--- a/database.py
+++ b/database.py
@@ -165,7 +165,7 @@ class Assignment(Base):
                       )
 
 # Database initialization function
-def init_db(database_path: str):
+def init_db(database_uri: str):
     """
     Initializes the database and creates all tables.
 
@@ -173,7 +173,7 @@ def init_db(database_path: str):
         database_path (str): The path to the SQLite database file.
         seed_data (bool): If True, the database will be seeded with deterministic test data.
     """
-    engine = create_engine(database_path)
+    engine = create_engine(database_uri)
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import tempfile
 import os
 from playwright.sync_api import Page, BrowserContext
 
-from database import get_db, seed_test_data
+from utils.populate_database import populate_database
 
 @pytest.fixture(scope='session')
 def test_db_path():
@@ -28,15 +28,9 @@ def app(test_db_path):
     
     test_config = {
         'TESTING': True,
-        'DATABASE': test_db_path,
-        'SQLALCHEMY_DATABASE_URI': f'sqlite:///{test_db_path}',
-        'DEBUG': True,
-        'SECRET_KEY': 'test-secret-key',
-        'SEED_DATABASE_FOR_TESTING': True,
-        'INSERT_DUMMY_DATA': True,
     }
     
-    app = create_app(login_manager=login_manager, test_config=test_config)
+    app = create_app(login_manager=login_manager, config_override=test_config)
     
     yield app
 
@@ -48,7 +42,7 @@ def rollback_db_after_test(app):
     
     # After test completes, rollback any uncommitted changes
     with app.app_context():
-        seed_test_data(app.config['SQLALCHEMY_SESSION'])  # Reseed data to initial state
+        populate_database(app.config['SQLALCHEMY_DATABASE_URI'])  # Reseed data to initial state
 
 @pytest.fixture
 def goto(page, live_server):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ def app(test_db_path):
     }
     
     app = create_app(login_manager=login_manager, config_override=test_config)
+    populate_database(app.config['SQLALCHEMY_DATABASE_URI'])
     
     yield app
 

--- a/utils/database.py
+++ b/utils/database.py
@@ -1,6 +1,6 @@
 import os
 from config import Config
-from database import init_db, seed_database
+from database import init_db, insert_dummy_data
 
 
 def populate_database(database_uri: str):
@@ -17,5 +17,5 @@ def populate_database(database_uri: str):
             os.makedirs(database_dir)
 
     Session = init_db(database_uri)
-    seed_database(Session)
+    insert_dummy_data(Session)
     print("Database populated with dummy data.")

--- a/utils/database.py
+++ b/utils/database.py
@@ -1,0 +1,21 @@
+import os
+from config import Config
+from database import init_db, seed_database
+
+
+def populate_database(database_uri: str):
+    """This function populates the database with dummy data for testing purposes.
+    
+    Args:
+        database_uri (str): The database URI where the dummy data will be inserted.
+    """
+    
+    if "sqlite:///" in database_uri:
+        database_path = database_uri.replace("sqlite:///", "")
+        database_dir = os.path.dirname(database_path)
+        if not os.path.exists(database_dir):
+            os.makedirs(database_dir)
+
+    Session = init_db(database_uri)
+    seed_database(Session)
+    print("Database populated with dummy data.")

--- a/utils/populate_database.py
+++ b/utils/populate_database.py
@@ -19,3 +19,6 @@ def populate_database(database_uri: str):
     Session = init_db(database_uri)
     insert_dummy_data(Session)
     print("Database populated with dummy data.")
+
+if __name__ == '__main__':
+    populate_database(Config.SQLALCHEMY_DATABASE_URI)


### PR DESCRIPTION
Decouple the population and initialization of the database. 

- **removed app argument and database seeding from init db**
- **created config and test config classes**
- **refactored create app to use config classes and new init db signature**
- **implemented populate database method to insert data outside of app context**
- **init db: renamed database path argument to database uri**
- **renamed seed_test_data to insert_dummy_data**
- **removed default memory SQLlite database for testing config**
- **used new create app signature and execute populate database after creating app.**
- **updated create app signature default config to an empty dictionary**
- **renamed populate database file**
- **removed redundant testing flags**
- **updated conftest file to use new create app signature and populate database method**
